### PR TITLE
Fix path to Rubocop configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --update add --no-cache --virtual run-dependencies build-base git
 
 COPY LICENSE.md README.md /
 
-RUN git clone --depth 1 https://github.com/Homebrew/brew Homebrew
+RUN git clone --depth 1 https://github.com/NSHipster/homebrew Homebrew
 
 COPY Gemfile /
 RUN bundle install -j 8

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -122,7 +122,7 @@ begin
     tempfile = Tempfile.new("#{repo.name}.rb")
     File.write tempfile, updated_formula
 
-    logger.debug `rubocop -c Homebrew/Library/Homebrew/.rubocop.yml -x #{tempfile.path}`
+    logger.debug `rubocop -c Homebrew/Library/.rubocop.yml -x #{tempfile.path}`
     updated_formula = File.read(tempfile)
   ensure
     tempfile.close


### PR DESCRIPTION
This action does a shallow clone of Homebrew to get at its `.rubocop.yml` file, which is used to format formulas after they're generated. However, this hardcoded path was broken by https://github.com/Homebrew/brew/commit/21d57a0c443cd3675bee25fb69a7228539f6b9e6, which moved it up to the parent directory.

This  PR fixes the hardcoded path and substitutes our own fork of `Homebrew/brew` to prevent unintentional breakage in the future.
