### PR TITLE
fixes for linter run by github-actions in tap repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apk --update add --no-cache --virtual run-dependencies build-base git
 COPY LICENSE.md README.md /
 
 RUN git clone --depth 1 https://github.com/NSHipster/homebrew Homebrew
-COPY Homebrew/Library /Library
 
 COPY Gemfile /
 RUN bundle install -j 8

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --update add --no-cache --virtual run-dependencies build-base git
 COPY LICENSE.md README.md /
 
 RUN git clone --depth 1 https://github.com/NSHipster/homebrew Homebrew
-COPY Homebrew /
+COPY Homebrew/Library /Library
 
 COPY Gemfile /
 RUN bundle install -j 8

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -154,7 +154,7 @@ begin
   else
     client.update_contents(options[:tap],
                            options[:formula],
-                           "Update #{repo.name} to #{latest_release.tag_name}",
+                           options[:message] ? options[:message] : "Update #{repo.name} to #{latest_release.tag_name}",
                            blob.sha,
                            updated_formula)
   end

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -116,11 +116,11 @@ begin
     end
 
     bottle_expression = <<~RUBY
-        bottle do
-          root_url "#{root_url}"
-    #{"      rebuild #{rebuild}\n" if rebuild}
-          #{bottles.join("\n    ")}
-        end
+      bottle do
+        root_url "#{root_url}"
+  #{"      rebuild #{rebuild}\n" if rebuild}
+        #{bottles.join("\n    ")}
+      end
     RUBY
 
     if (bottle = ast.descendants.find { |d| d.block_type? && d.send_node&.method_name == :bottle })
@@ -139,7 +139,7 @@ begin
     tempfile = Tempfile.new("#{repo.name}.rb")
     File.write tempfile, updated_formula
 
-    logger.debug `rubocop -c Library/.rubocop.yml -x #{tempfile.path}`
+    logger.debug `rubocop -c Homebrew/Library/.rubocop.yml -x #{tempfile.path}`
     updated_formula = File.read(tempfile)
   ensure
     tempfile.close

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -116,9 +116,9 @@ begin
     end
 
     bottle_expression = <<~RUBY
-      bottle do
+        bottle do
           root_url "#{root_url}"
-          #{"rebuild #{rebuild}\n" if rebuild}
+    #{"      rebuild #{rebuild}\n" if rebuild}
           #{bottles.join("\n    ")}
         end
     RUBY
@@ -139,7 +139,7 @@ begin
     tempfile = Tempfile.new("#{repo.name}.rb")
     File.write tempfile, updated_formula
 
-    logger.debug `rubocop -c Homebrew/Library/.rubocop.yml -x #{tempfile.path}`
+    logger.debug `rubocop -c Library/.rubocop.yml -x #{tempfile.path}`
     updated_formula = File.read(tempfile)
   ensure
     tempfile.close


### PR DESCRIPTION
Thanks for providing this super useful GitHub Action!

I saw a couple of minor errors when running it. The first is in my project repo where the action runs:

```
Configuration file not found: /github/workspace/Homebrew/Library/.rubocop.yml
```
I think coming from:
```ruby
logger.debug `rubocop -c Homebrew/Library/.rubocop.yml -x #{tempfile.path}`
```
which is think is due to:
```dockerfile
COPY Homebrew /
```
(contents of `Homebrew` copied to `/` so there is no `Homebrew` top level dir)

The second is after it pushes the changes back to my tap repo I get some errors in the tap repo from the `brew test-bot --only-tap-syntax` GitHub Action that was installed automatically when I did `brew tap-new` to create it.
```
Error: Inconsistent indentation detected.
Error: Use 2 (not 0) spaces for indentation.
Error: Trailing whitespace detected.
Error: `end` at 12, 2 is not aligned with `bottle do` at 8, 0.
Error: Extra blank line detected.
Error: Trailing whitespace detected.
```
coming from:
```ruby
    bottle_expression = <<~RUBY
      bottle do
          root_url "#{root_url}"
          #{"rebuild #{rebuild}\n" if rebuild}
          #{bottles.join("\n    ")}
        end
    RUBY
```
e.g. https://github.com/anentropic/homebrew-tap/runs/2487670091