### PR TITLE
A few minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ RUN apk --update add --no-cache --virtual run-dependencies build-base git
 
 COPY LICENSE.md README.md /
 
-RUN git clone --depth 1 https://github.com/NSHipster/homebrew Homebrew
-COPY Homebrew /
+RUN git clone --depth 1 --branch 3.1.5 https://github.com/Homebrew/brew Homebrew
 
 COPY Gemfile /
 RUN bundle install -j 8

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,8 @@ runs:
       "${{ inputs.tap }}",
       --formula,
       "${{ inputs.formula }}",
+      --message,
+      "${{ inputs.message }}",
     ]
 
 branding:


### PR DESCRIPTION
Thanks for making this super useful GitHub Action!

I encountered a couple of small issues when running it... mainly rubocop errors from the auto-installed github actions in my tap repo after changes are pushed. e.g. https://github.com/anentropic/homebrew-tap/runs/2487670091?check_suite_focus=true

It was looking in wrong path for `.rubocop.yml` so the auto fixup wasn't running. I'm not sure if you had a reason for using forked `brew` repo, but it seems to work fine with the current upstream version and would be good to stay in sync.

After that I had one more rubocop issue which was that it didn't like it if the `bottle` block was inserted before `license`. Which it was currently, due to inserting after `url`. (Rubocop wouldn't auto fix that one). So I changed it to search in order and insert after `license`, or after `url if `license` not found.

Also the commit message input wasn't connected up, which is useful to have.