### PR TITLE
Add a name override for formulae with different names then the github repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ pasting your token into the "Value" field.
 - `formula`:
   **Required**.
   The path to the formula in the tap repository (e.g. Formula/hello.rb).
+- `name`:
+  _Optional_.
+  Overrides the name of the formula, if it differs from the github repository (eg. hello); if not sets, defaults to the repository name
 - `message`:
   _Optional_.
   The message of the commit updating the formula. (e.g. "Update hello to 1.0.1")
@@ -233,6 +236,7 @@ jobs:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
+          #Note: When using `name` to override the formula name, you need to also use it here (where it says "hello" here)
           asset_path: ./hello--${{ github.event.release.tag_name }}.catalina.bottle.tar.gz
           asset_name: hello-${{ github.event.release.tag_name }}.catalina.bottle.tar.gz
           asset_content_type: application/gzip

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,11 @@ inputs:
       The path to the formula in the tap repository
       (e.g. Formula/hello.rb)
     required: true
+  name:
+    description: |
+      The name of the homebrew formula. Defaults to the repository name
+      (e.g. hello)
+    required: false
   message:
     description: |
       The message of the commit updating the formula.
@@ -38,6 +43,8 @@ runs:
       "${{ inputs.formula }}",
       --message,
       "${{ inputs.message }}",
+      --name,
+      "${{ inputs.name }}",
     ]
 
 branding:

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -26,6 +26,10 @@ OptionParser.new do |opts|
     options[:tap] = repository
   end
 
+  opts.on("-n", "--name NAME", "The name of the formula in Homebrew") do |repository|
+    options[:name] = repository
+  end
+
   opts.on("-f", "--formula PATH", "The path to the formula in the tap repository") do |path|
     options[:formula] = path
   end
@@ -73,7 +77,11 @@ begin
     raise "Tag #{latest_release.tag_name} not found"
   end
 
-  PATTERN = /#{Regexp.quote(repo.name)}-#{Regexp.quote(latest_release.tag_name.delete_prefix("v"))}\.(?<platform>[^.]+)\.bottle\.((?<rebuild>[\d]+)\.)?tar\.gz/.freeze
+  formula_name = repo.name
+  if options[:name]
+    formula_name = options[:name]
+  end
+  PATTERN = /#{Regexp.quote(formula_name)}-#{Regexp.quote(latest_release.tag_name.delete_prefix("v"))}\.(?<platform>[^.]+)\.bottle\.((?<rebuild>[\d]+)\.)?tar\.gz/.freeze
 
   assets = {}
   rebuild = nil
@@ -158,7 +166,7 @@ begin
     logger.warn "Formula is up-to-date"
     exit 0
   else
-    commit_message = options[:message].empty? ? "Update #{repo.name} to #{latest_release.tag_name}" : options[:message]
+    commit_message = options[:message].empty? ? "Update #{formula_name} to #{latest_release.tag_name}" : options[:message]
     logger.info commit_message
     client.update_contents(options[:tap],
                            options[:formula],


### PR DESCRIPTION
This solves #16.
We provide an override, that changes the formula name.

If not provided, falls back to repository name, just as before